### PR TITLE
Edgecore binary soft link

### DIFF
--- a/core/core.sh
+++ b/core/core.sh
@@ -103,7 +103,6 @@ swapoff -a
 #install keadm
 /bin/su - core -c "mkdir bin"
 /bin/su - core -c "/usr/bin/wget https://github.com/kubeedge/kubeedge/releases/download/v1.6.0/keadm-v1.6.0-linux-amd64.tar.gz; tar -xzf keadm-v1.6.0-linux-amd64.tar.gz; ln -s /home/core/keadm-v1.6.0-linux-amd64/keadm/keadm /home/core/bin/"
-cp /etc/kubedge/edgecore to /usr/local/bin/edgecore
 /bin/su - core -c "sudo /home/core/bin/keadm init --advertise-address=\"$STARTIP\" --kube-config=/home/core/.kube/config"
 
 #start rabbitMQ

--- a/core/core.sh
+++ b/core/core.sh
@@ -103,6 +103,7 @@ swapoff -a
 #install keadm
 /bin/su - core -c "mkdir bin"
 /bin/su - core -c "/usr/bin/wget https://github.com/kubeedge/kubeedge/releases/download/v1.6.0/keadm-v1.6.0-linux-amd64.tar.gz; tar -xzf keadm-v1.6.0-linux-amd64.tar.gz; ln -s /home/core/keadm-v1.6.0-linux-amd64/keadm/keadm /home/core/bin/"
+cp /etc/kubedge/edgecore to /usr/local/bin/edgecore
 /bin/su - core -c "sudo /home/core/bin/keadm init --advertise-address=\"$STARTIP\" --kube-config=/home/core/.kube/config"
 
 #start rabbitMQ

--- a/worker/worker.sh
+++ b/worker/worker.sh
@@ -53,6 +53,7 @@ make && make install
 #install keadm
 /bin/su - worker -c "mkdir bin"
 /bin/su - worker -c "/usr/bin/wget https://github.com/kubeedge/kubeedge/releases/download/v1.6.0/keadm-v1.6.0-linux-amd64.tar.gz; tar -xzf keadm-v1.6.0-linux-amd64.tar.gz; ln -s /home/worker/keadm-v1.6.0-linux-amd64/keadm/keadm /home/worker/bin/"
+cp /etc/kubedge/edgecore /usr/local/bin/edgecore
 ##replace line below with token, generated with this command on core node:
 ##/bin/su - core -c "sudo /home/core/bin/keadm gettoken --kube-config=/home/core/.kube/config"
 #commenting out this line for now and just going to echo a reminder at the end of the script.

--- a/worker/worker.sh
+++ b/worker/worker.sh
@@ -53,7 +53,7 @@ make && make install
 #install keadm
 /bin/su - worker -c "mkdir bin"
 /bin/su - worker -c "/usr/bin/wget https://github.com/kubeedge/kubeedge/releases/download/v1.6.0/keadm-v1.6.0-linux-amd64.tar.gz; tar -xzf keadm-v1.6.0-linux-amd64.tar.gz; ln -s /home/worker/keadm-v1.6.0-linux-amd64/keadm/keadm /home/worker/bin/"
-cp /etc/kubedge/edgecore /usr/local/bin/edgecore
+ln -s /etc/kubeedge/edgecore /usr/local/bin/
 ##replace line below with token, generated with this command on core node:
 ##/bin/su - core -c "sudo /home/core/bin/keadm gettoken --kube-config=/home/core/.kube/config"
 #commenting out this line for now and just going to echo a reminder at the end of the script.

--- a/worker/worker.sh
+++ b/worker/worker.sh
@@ -52,8 +52,7 @@ make && make install
 
 #install keadm
 /bin/su - worker -c "mkdir bin"
-/bin/su - worker -c "/usr/bin/wget https://github.com/kubeedge/kubeedge/releases/download/v1.6.0/keadm-v1.6.0-linux-amd64.tar.gz; tar -xzf keadm-v1.6.0-linux-amd64.tar.gz; ln -s /home/worker/keadm-v1.6.0-linux-amd64/keadm/keadm /home/worker/bin/"
-ln -s /etc/kubeedge/edgecore /usr/local/bin/
+/bin/su - worker -c "/usr/bin/wget https://github.com/kubeedge/kubeedge/releases/download/v1.6.0/keadm-v1.6.0-linux-amd64.tar.gz; tar -xzf keadm-v1.6.0-linux-amd64.tar.gz; ln -s /home/worker/keadm-v1.6.0-linux-amd64/keadm/keadm /home/worker/bin/ ln -s /etc/kubeedge/edgecore /usr/local/bin/"
 ##replace line below with token, generated with this command on core node:
 ##/bin/su - core -c "sudo /home/core/bin/keadm gettoken --kube-config=/home/core/.kube/config"
 #commenting out this line for now and just going to echo a reminder at the end of the script.

--- a/worker/worker.sh
+++ b/worker/worker.sh
@@ -52,7 +52,8 @@ make && make install
 
 #install keadm
 /bin/su - worker -c "mkdir bin"
-/bin/su - worker -c "/usr/bin/wget https://github.com/kubeedge/kubeedge/releases/download/v1.6.0/keadm-v1.6.0-linux-amd64.tar.gz; tar -xzf keadm-v1.6.0-linux-amd64.tar.gz; ln -s /home/worker/keadm-v1.6.0-linux-amd64/keadm/keadm /home/worker/bin/ ln -s /etc/kubeedge/edgecore /usr/local/bin/"
+/bin/su - worker -c "/usr/bin/wget https://github.com/kubeedge/kubeedge/releases/download/v1.6.0/keadm-v1.6.0-linux-amd64.tar.gz; tar -xzf keadm-v1.6.0-linux-amd64.tar.gz; ln -s /home/worker/keadm-v1.6.0-linux-amd64/keadm/keadm /home/worker/bin/"
+/bin/su - worker -c "sudo ln -s /etc/kubeedge/edgecore /usr/local/bin/"
 ##replace line below with token, generated with this command on core node:
 ##/bin/su - core -c "sudo /home/core/bin/keadm gettoken --kube-config=/home/core/.kube/config"
 #commenting out this line for now and just going to echo a reminder at the end of the script.


### PR DESCRIPTION
keadm join results in deploying edgecore.service with details shown below. edgecore.service expects the edgecore binary to exist at /usr/local/bin/edgecore.
However, keadm installation via GitHub unpackages edgecore binary at /etc/kubedge/edgecore. This resulted in the edgecore process failure to start.
I updated the post boot scripts to manually copy the edgecore binary at the /usr/local/bin/edgecore and was able to resolve the issue.
I tested it on Chameleon KVM as I could not get resources on Exogeni. 


[root@flynet1worker1 ~]# cat /etc/systemd/system/edgecore.service
[Unit]
Description=edgecore.service
[Service]
Type=simple
ExecStart=/usr/local/bin/edgecore
Restart=always
RestartSec=10
[Install]
WantedBy=multi-user.target
[root@flynet1worker1 ~]#