### PR TITLE
changes to install kubernetes version 1.21 which works with kubeedge

### DIFF
--- a/core/core.sh
+++ b/core/core.sh
@@ -43,7 +43,7 @@ gpgcheck=1
 repo_gpgcheck=1
 gpgkey=https://packages.cloud.google.com/yum/doc/yum-key.gpg https://packages.cloud.google.com/yum/doc/rpm-package-key.gpg
 EOF
-yum install -y kubelet kubeadm kubectl
+yum install -y kubelet-1.21.4-0.x86_64 kubeadm-1.21.4-0.x86_64 kubectl-1.21.4-0.x86_64
 systemctl enable kubelet
 systemctl start kubelet
 #hostnamectl set-hostname master-node
@@ -56,26 +56,6 @@ for i in $(seq $WORKERS); do
     echo $WORKERIP worker$i.flynetdemo.edu worker-node$i node$i worker$i >> /etc/hosts
 done
 
-#open firewall holes for kubernetes and rabbitmq
-#systemctl enable firewalld
-#systemctl start firewalld
-#firewall-cmd --permanent --add-port=22/tcp
-#firewall-cmd --permanent --add-port=2379-2380/tcp
-#firewall-cmd --permanent --add-port=4369/tcp
-#firewall-cmd --permanent --add-port=5671-5672/tcp
-#firewall-cmd --permanent --add-port=6443/tcp
-#firewall-cmd --permanent --add-port=8883/tcp
-#firewall-cmd --permanent --add-port=10000/tcp
-#firewall-cmd --permanent --add-port=10002/tcp
-#firewall-cmd --permanent --add-port=10250/tcp
-#firewall-cmd --permanent --add-port=10251/tcp
-#firewall-cmd --permanent --add-port=10252/tcp
-#firewall-cmd --permanent --add-port=10255/tcp
-#firewall-cmd --permanent --add-port=15672/tcp
-#firewall-cmd --permanent --add-port=25672/tcp
-#firewall-cmd --permanent --add-port=61613-61614/tcp
-
-#firewall-cmd --reload
 cat <<EOF > /etc/sysctl.d/k8s.conf
 net.bridge.bridge-nf-call-ip6tables = 1
 net.bridge.bridge-nf-call-iptables = 1
@@ -106,10 +86,10 @@ swapoff -a
 /bin/su - core -c "sudo /home/core/bin/keadm init --advertise-address=\"$STARTIP\" --kube-config=/home/core/.kube/config"
 
 #start rabbitMQ
-cp -r /root/core/* /home/core
-chown -R core /home/core
-chgrp -R core /home/core
-
+/bin/su - core -c "/usr/bin/wget https://emmy8.casa.umass.edu/flynetDemo/core/docker-compose.yml"
+/bin/su - core -c "/usr/bin/wget https://emmy8.casa.umass.edu/flynetDemo/core/rabbitmq.tar; /bin/tar -xf rabbitmq.tar"
 /bin/su - core -c "sudo systemctl restart docker" #possibly some strange bug?
 /bin/su - core -c "/usr/local/bin/docker-compose up -d"
 
+#get codes to talk to basestation... these aren't ready yet
+#/bin/su - core -c "/usr/bin/wget https://emmy8.casa.umass.edu/flynetDemo/core/talkToBasestation.tar; /bin/tar -xf talkToBasestation.tar"


### PR DESCRIPTION
Addresses following issues:
- kubernetes version 1.22 does not work with kubedge

This results in failure to setup kubernetes cluster and keadm init also fails