### PR TITLE
K8s version

### DIFF
--- a/core/core.sh
+++ b/core/core.sh
@@ -83,6 +83,7 @@ swapoff -a
 #install keadm
 /bin/su - core -c "mkdir bin"
 /bin/su - core -c "/usr/bin/wget https://github.com/kubeedge/kubeedge/releases/download/v1.6.0/keadm-v1.6.0-linux-amd64.tar.gz; tar -xzf keadm-v1.6.0-linux-amd64.tar.gz; ln -s /home/core/keadm-v1.6.0-linux-amd64/keadm/keadm /home/core/bin/"
+sleep 60
 /bin/su - core -c "sudo /home/core/bin/keadm init --advertise-address=\"$STARTIP\" --kube-config=/home/core/.kube/config"
 
 #start rabbitMQ

--- a/core/core.sh
+++ b/core/core.sh
@@ -83,7 +83,8 @@ swapoff -a
 #install keadm
 /bin/su - core -c "mkdir bin"
 /bin/su - core -c "/usr/bin/wget https://github.com/kubeedge/kubeedge/releases/download/v1.6.0/keadm-v1.6.0-linux-amd64.tar.gz; tar -xzf keadm-v1.6.0-linux-amd64.tar.gz; ln -s /home/core/keadm-v1.6.0-linux-amd64/keadm/keadm /home/core/bin/"
-sleep 300
+# Without the sleep, keadm init fails with different panic errors; it doesn't seem to work with smaller delays either
+sleep 600
 /bin/su - core -c "sudo /home/core/bin/keadm init --advertise-address=\"$STARTIP\" --kube-config=/home/core/.kube/config"
 
 #start rabbitMQ

--- a/core/core.sh
+++ b/core/core.sh
@@ -83,7 +83,7 @@ swapoff -a
 #install keadm
 /bin/su - core -c "mkdir bin"
 /bin/su - core -c "/usr/bin/wget https://github.com/kubeedge/kubeedge/releases/download/v1.6.0/keadm-v1.6.0-linux-amd64.tar.gz; tar -xzf keadm-v1.6.0-linux-amd64.tar.gz; ln -s /home/core/keadm-v1.6.0-linux-amd64/keadm/keadm /home/core/bin/"
-sleep 60
+sleep 300
 /bin/su - core -c "sudo /home/core/bin/keadm init --advertise-address=\"$STARTIP\" --kube-config=/home/core/.kube/config"
 
 #start rabbitMQ


### PR DESCRIPTION
Introduced a delay before the keadm start
Without the sleep, keadm init fails with different panic errors; it doesn't seem to work with smaller delays either